### PR TITLE
Fix malformed URL on Tuning dd block size

### DIFF
--- a/_posts/2015-01-04-tuning-dd-block-size.md
+++ b/_posts/2015-01-04-tuning-dd-block-size.md
@@ -277,6 +277,6 @@ Thanks for reading!
 [GitHub - dd_obs_test.sh]: https://github.com/tdg5/blog/blob/master/_includes/scripts/dd_obs_test.sh "GitHub.com - tdg5/blog - dd_obs_test.sh"
 [GitHub - dd_ibs_test.sh]: https://github.com/tdg5/blog/blob/master/_includes/scripts/dd_ibs_test.sh "GitHub.com - tdg5/blog - dd_ibs_test.sh"
 [KNOPPIX]: http://www.knopper.net/knoppix/index-en.html "KNOPPIX"
-[Manpage - dd]: (http://man7.org/linux/man-pages/man1/dd.1.html) "Manpage - dd"
+[Manpage - dd]: http://man7.org/linux/man-pages/man1/dd.1.html "Manpage - dd"
 [Wikipedia - dd - Block Size]: https://en.wikipedia.org/wiki/Dd_(Unix)#Block_size "Wikipedia - dd - Block Size"
 [YouTube - Mongo DB Is Web Scale]: https://www.youtube.com/watch?v=b2F-DItXtZs&t=1m42s "YouTube - Mongo DB Is Web Scale"


### PR DESCRIPTION
Hi :wave: 

I was reading through http://blog.tdg5.com/tuning-dd-block-size/
and when checking the footnotes I noticed that the second one ("dd's ibs (input block size) and obs (output block size) arguments both default to 512 bytes") is malformed.

Unsure if this fixes it, but I think so.