### PR TITLE
Fix the automatic deletion of test files created by the scripts

### DIFF
--- a/_includes/scripts/dd_ibs_test.sh
+++ b/_includes/scripts/dd_ibs_test.sh
@@ -44,4 +44,4 @@ do
 done
 
 # Clean up the test file if we created one
-if [ $TEST_FILE_EXISTS -ne 0 ]; then rm $TEST_FILE; fi
+if [ $TEST_FILE_EXISTS -eq 0 ]; then rm $TEST_FILE; fi

--- a/_includes/scripts/dd_obs_test.sh
+++ b/_includes/scripts/dd_obs_test.sh
@@ -37,7 +37,7 @@ do
   TRANSFER_RATE=$(echo $DD_RESULT | \grep --only-matching -E '[0-9.]+ ([MGk]?B|bytes)/s(ec)?')
 
   # Clean up the test file if we created one
-  if [ $TEST_FILE_EXISTS -ne 0 ]; then rm $TEST_FILE; fi
+  if [ $TEST_FILE_EXISTS -eq 0 ]; then rm $TEST_FILE; fi
 
   # Output the result
   printf "$PRINTF_FORMAT" "$BLOCK_SIZE" "$TRANSFER_RATE"


### PR DESCRIPTION
Thank you for your awesome scripts! I noticed that they are deleting test files that preexist, whereas test files created by the scripts are not being deleted. This Boolean logic change fixes that.